### PR TITLE
Fix lesson 3 tests so that pipes are actually processed by shell

### DIFF
--- a/david/CMakeLists.txt
+++ b/david/CMakeLists.txt
@@ -8,9 +8,9 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 add_executable(prompt_name prompt_name.cpp)
 
 enable_testing()
-add_test(NAME test_prompt_name0 COMMAND echo "David" | prompt_name)
+add_test(NAME test_prompt_name0 COMMAND "/bin/sh" "-c" "echo David | ./prompt_name")
 set_tests_properties(test_prompt_name0
-  PROPERTIES PASS_REGULAR_EXPRESSION "David")
-add_test(NAME test_prompt_name1 COMMAND echo "Michael Mauer" | prompt_name)
+  PROPERTIES PASS_REGULAR_EXPRESSION "Hello, David")
+add_test(NAME test_prompt_name1 COMMAND "/bin/sh" "-c" "echo Michael Mauer | ./prompt_name")
 set_tests_properties(test_prompt_name1
-  PROPERTIES PASS_REGULAR_EXPRESSION "Michael Mauer")
+  PROPERTIES PASS_REGULAR_EXPRESSION "Hello, Michael Mauer")


### PR DESCRIPTION
Fixes #6. The command run is now "/bin/sh -c", which makes sure that the shell actually sees the pipe. I'm also testing the output of the program more fully now.
